### PR TITLE
Added registry entry for enabling NTP when machine was previously in a domain

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@
 #
 # Document parameters here.
 #
-# * 'servers' 
+# * 'servers'
 # A hash of time servers, including the configuration flags as follows:
 #
 # 0x01 SpecialInterval
@@ -45,6 +45,11 @@ class windowstime (
 ) inherits windowstime::params {
   validate_hash($servers)
   $regvalue = maptoreg($servers)
+  registry_value { 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time\Parameters\Type':
+    ensure => present,
+    type   => string,
+    data   => 'NTP'
+  }
   registry_value { 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time\Parameters\NtpServer':
     ensure => present,
     type   => string,


### PR DESCRIPTION
The Windows Server documentation on the registry entries for W32Time call out that the value for the "Type" registry entry above must be NTP in order to use the time server noted in the "NtpServer" registry entry. When a Windows machine is NOT a member of the domain, the value is NTP, all good. But when the machine joins a domain, the value becomes NT5DS. So, this commit will make sure the time server is set correctly, even if the machine joins a domain.
